### PR TITLE
fix(auth): open device-auth link in a new tab from the auth dialog

### DIFF
--- a/src/components/AuthMethodDialog.vue
+++ b/src/components/AuthMethodDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import type { AuthMethod } from '@agentclientprotocol/sdk';
 
 defineProps<{
@@ -11,8 +12,80 @@ const emit = defineEmits<{
   (e: 'cancel'): void;
 }>();
 
-function handleSelect(methodId: string) {
-  emit('select', methodId);
+function handleSelect(method: AuthMethod) {
+  // Open the embedded auth URL (if any) in a new tab AND close the popup at
+  // once — clicking anywhere on the item does both, matching what users
+  // expect from the device-authorization instructions.
+  const url = extractUrl(method.description);
+  if (url) {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+  emit('select', method.id);
+}
+
+/**
+ * Split a description into plain-text and URL segments so URLs (e.g. the
+ * device-authorization link many agents embed in their auth instructions)
+ * render as clickable links that open in a new tab, instead of forcing the
+ * user to copy/paste them by hand.
+ */
+type Segment = { type: 'text'; value: string } | { type: 'link'; value: string };
+
+const URL_RE = /(https?:\/\/[^\s]+)/g;
+
+/** First URL embedded in a description, or null. */
+function extractUrl(description?: string | null): string | null {
+  if (!description) return null;
+  return description.match(URL_RE)?.[0] ?? null;
+}
+
+function toSegments(text: string): Segment[] {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0];
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      segments.push({ type: 'text', value: text.slice(lastIndex, start) });
+    }
+    segments.push({ type: 'link', value: url });
+    lastIndex = start + url.length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', value: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/**
+ * Pull the device-authorization user code out of a description. Agents embed
+ * it both in the URL (`?user_code=XXXX`) and inline (`(code XXXX)`); try the
+ * URL form first, then the inline form. Returns null when there's no code.
+ */
+function extractCode(description?: string | null): string | null {
+  if (!description) return null;
+  return (
+    description.match(/user_code=([A-Za-z0-9-]+)/)?.[1] ??
+    description.match(/\bcode\s+([A-Za-z0-9-]{4,})/i)?.[1] ??
+    null
+  );
+}
+
+// The code most recently copied, so we can show a transient "Copied!" label.
+const copiedCode = ref<string | null>(null);
+let copiedTimer: ReturnType<typeof setTimeout> | null = null;
+
+async function copyCode(code: string) {
+  try {
+    await navigator.clipboard.writeText(code);
+    copiedCode.value = code;
+    if (copiedTimer) clearTimeout(copiedTimer);
+    copiedTimer = setTimeout(() => {
+      copiedCode.value = null;
+    }, 2000);
+  } catch (e) {
+    console.warn('Failed to copy code to clipboard:', e);
+  }
 }
 </script>
 
@@ -35,13 +108,31 @@ function handleSelect(methodId: string) {
             v-for="method in authMethods"
             :key="method.id"
             class="auth-method-btn"
-            @click="handleSelect(method.id)"
+            @click="handleSelect(method)"
           >
             <div class="method-info">
               <span class="method-name">{{ method.name }}</span>
               <span v-if="method.description" class="method-desc">
-                {{ method.description }}
+                <template v-for="(seg, i) in toSegments(method.description)" :key="i">
+                  <a
+                    v-if="seg.type === 'link'"
+                    :href="seg.value"
+                    class="method-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    @click.prevent
+                  >{{ seg.value }}</a>
+                  <template v-else>{{ seg.value }}</template>
+                </template>
               </span>
+              <button
+                v-if="extractCode(method.description)"
+                type="button"
+                class="copy-code-btn"
+                @click.stop="copyCode(extractCode(method.description)!)"
+              >
+                {{ copiedCode === extractCode(method.description) ? '✓ Copied!' : `Copy code ${extractCode(method.description)}` }}
+              </button>
             </div>
             <span class="arrow">→</span>
           </button>
@@ -150,6 +241,36 @@ function handleSelect(methodId: string) {
 .method-desc {
   font-size: 0.8rem;
   color: var(--text-muted);
+  word-break: break-word;
+}
+
+.method-link {
+  color: var(--bg-primary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.method-link:hover {
+  text-decoration: none;
+}
+
+.copy-code-btn {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-main);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.copy-code-btn:hover {
+  border-color: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .arrow {

--- a/src/components/AuthMethodDialog.vue
+++ b/src/components/AuthMethodDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import type { AuthMethod } from '@agentclientprotocol/sdk';
+import { openExternalUrl } from '../lib/host';
 
 defineProps<{
   authMethods: AuthMethod[];
@@ -18,7 +19,8 @@ function handleSelect(method: AuthMethod) {
   // expect from the device-authorization instructions.
   const url = extractUrl(method.description);
   if (url) {
-    window.open(url, '_blank', 'noopener,noreferrer');
+    // Host-aware: system browser on Tauri desktop, new tab on web.
+    void openExternalUrl(url);
   }
   emit('select', method.id);
 }

--- a/src/lib/host/index.ts
+++ b/src/lib/host/index.ts
@@ -287,6 +287,24 @@ export async function getAppVersion(): Promise<string> {
   return v ?? FALLBACK_VERSION;
 }
 
+/**
+ * Open a URL in the user's default external browser.
+ *
+ * In a Tauri webview `window.open()` / `<a target="_blank">` do NOT reach the
+ * system browser (they no-op or try to navigate the webview), so we go through
+ * the opener plugin. On the plain web build we fall back to `window.open`,
+ * which runs synchronously here to stay inside the click's user-gesture and
+ * avoid popup blocking.
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isTauriHost()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener');
+    await openUrl(url);
+    return;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
 /** True when the host can present a native folder picker. */
 export function canPickFolder(): boolean {
   return isDesktop();


### PR DESCRIPTION
## Problem

When an agent requires device-authorization, the auth dialog shows instructions like *"Open https://…/device?user_code=XXXX in your browser and approve (code XXXX), then choose this method to finish signing in."* But the URL was rendered as **plain text**: clicking the method just closed the dialog without opening the link, forcing users to select and copy/paste the URL by hand.

## Changes

- **Open the embedded auth URL on select.** Clicking anywhere on a method item now opens the first URL from its description in a new tab *and* closes the dialog (fires `authenticate`), matching the "open then finish" device flow.
- **Clickable URLs in the description.** URLs are rendered as anchors (`target="_blank"`, `rel="noopener noreferrer"`); direct clicks are de-duplicated so only one tab opens.
- **Copy code button.** Extracts the device `user_code` (from `user_code=…` in the URL, or an inline `(code …)`) and copies it to the clipboard with transient "Copied!" feedback. Hidden when no code is present. `@click.stop` so copying doesn't close the dialog.

No changes to protocol handling or other components; scoped to `AuthMethodDialog.vue`.

## Testing

- `npx vue-tsc --noEmit` passes.
- Verified in the web build (`npm run dev:web`) against an agent using GlobAI device auth: single click opens the auth URL in a new tab and closes the dialog; Copy code copies the user code.