### PR TITLE
fix(session): default working directory to /tmp when none is set

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,13 @@ const configStore = useConfigStore();
 const sessionStore = useSessionStore();
 
 const selectedAgent = ref('');
-const selectedCwd = ref('');
+// Default working directory used when the user hasn't picked/typed one. The
+// cwd is interpreted on the *agent's* host, so a POSIX temp dir is a safe
+// default for remote agents and avoids an unnecessary "enter a working
+// directory" error on the New Session flow. Desktop users normally override
+// it with the folder picker.
+const DEFAULT_CWD = '/tmp';
+const selectedCwd = ref(DEFAULT_CWD);
 // On mobile / web there is no native folder picker (and the cwd refers to
 // a path on the *agent's* machine, not the local device), so we expose a
 // free-text field instead of the picker button.
@@ -127,6 +133,7 @@ onMounted(async () => {
   if (savedCwd) {
     selectedCwd.value = savedCwd;
   }
+  // else: keep the DEFAULT_CWD prefilled above.
 
   // Hook foreground-reconnect listeners. `pageshow` fires both on initial
   // navigation and when iOS restores a frozen WebView from the back/forward
@@ -173,11 +180,9 @@ async function handleNewSession() {
   // most agents. On desktop the folder picker always returns an absolute
   // path, but on mobile the user types it, so validate up-front and surface
   // a helpful error rather than letting the agent reject `session/new`.
-  const cwd = selectedCwd.value.trim();
-  if (!cwd) {
-    sessionStore.error = 'Please enter a working directory (absolute path on the agent\u2019s machine).';
-    return;
-  }
+  // Fall back to DEFAULT_CWD when the field is empty so remote agents don't
+  // trip an avoidable "enter a working directory" error.
+  const cwd = selectedCwd.value.trim() || DEFAULT_CWD;
   const isAbsolute = cwd.startsWith('/') || /^[A-Za-z]:[\\/]/.test(cwd);
   if (!isAbsolute) {
     sessionStore.error = `Working directory must be an absolute path (got: ${cwd}).`;


### PR DESCRIPTION
## Problem

Starting a session with an empty **Working Directory** field fails fast with *"Please enter a working directory (absolute path on the agent's machine)."* For remote (WebSocket) agents the `cwd` is interpreted on the **agent's** host, not the client device, so forcing the user to type a path before they can connect is often unnecessary friction — especially on mobile/web where there's no folder picker.

## Change

- Prefill the Working Directory field with a POSIX default (`/tmp`).
- Fall back to that default in `handleNewSession` when the field is left empty, instead of erroring.
- The existing absolute-path validation still applies, and desktop users can still override via the native folder picker.

Scoped to `src/App.vue`.

## Testing

- `npx vue-tsc --noEmit` passes.
- Web build: creating a session against a remote agent with the field left at its default connects using `/tmp` instead of showing the error.