### PR TITLE
feat(elicitation): client-side URL-mode elicitation for tool authorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "acp-ui",
-  "version": "0.1.0",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acp-ui",
-      "version": "0.1.0",
+      "version": "0.1.16",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.13.1",
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@microsoft/applicationinsights-web": "^3.3.11",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -1381,7 +1381,6 @@
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2071,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -2272,7 +2270,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2331,7 +2328,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2413,7 +2409,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.13.1",
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@microsoft/applicationinsights-web": "^3.3.11",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import ChatView from './components/ChatView.vue';
 import PermissionDialog from './components/PermissionDialog.vue';
 import SettingsView from './components/SettingsView.vue';
 import AuthMethodDialog from './components/AuthMethodDialog.vue';
+import ElicitationDialog from './components/ElicitationDialog.vue';
 import TrafficMonitor from './components/TrafficMonitor.vue';
 import StartupProgress from './components/StartupProgress.vue';
 import type { SavedSession } from './lib/types';
@@ -95,6 +96,9 @@ async function handleManualReconnect() {
 
 // Watch for permission requests from session store
 const pendingPermission = computed(() => sessionStore.pendingPermission);
+
+// Watch for URL-mode elicitation requests (tool authorization)
+const pendingElicitation = computed(() => sessionStore.pendingElicitation);
 
 // Watch for auth method selection requests
 const pendingAuthMethods = computed(() => sessionStore.pendingAuthMethods);
@@ -226,6 +230,10 @@ function handleAuthMethodSelect(methodId: string) {
 
 function handleAuthMethodCancel() {
   sessionStore.cancelAuthSelection();
+}
+
+function handleElicitationRespond(action: 'accept' | 'decline' | 'cancel') {
+  sessionStore.resolveElicitation(action);
 }
 
 function toggleSidebar() {
@@ -446,12 +454,19 @@ function clearError() {
     />
 
     <!-- Auth Method Dialog -->
-    <AuthMethodDialog 
+    <AuthMethodDialog
       v-if="pendingAuthMethods.length > 0"
       :auth-methods="pendingAuthMethods"
       :agent-name="pendingAuthAgentName"
       @select="handleAuthMethodSelect"
       @cancel="handleAuthMethodCancel"
+    />
+
+    <!-- Elicitation Dialog (URL-mode tool authorization) -->
+    <ElicitationDialog
+      v-if="pendingElicitation"
+      :elicitation="pendingElicitation"
+      @respond="handleElicitationRespond"
     />
 
     <!-- Settings -->

--- a/src/components/ElicitationDialog.vue
+++ b/src/components/ElicitationDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ElicitationRequest, ElicitationAction } from '../lib/types';
+import { openExternalUrl } from '../lib/host';
 
 defineProps<{
   elicitation: ElicitationRequest;
@@ -31,9 +32,10 @@ function toSegments(text: string): Segment[] {
   return segments;
 }
 
-/** Open the authorization URL in a new tab without dismissing the dialog. */
+/** Open the authorization URL in the system browser (Tauri) or a new tab
+ * (web), without dismissing the dialog. */
 function openUrl(url: string) {
-  window.open(url, '_blank', 'noopener,noreferrer');
+  void openExternalUrl(url);
 }
 </script>
 
@@ -54,6 +56,7 @@ function openUrl(url: string) {
               class="msg-link"
               target="_blank"
               rel="noopener noreferrer"
+              @click.prevent="openUrl(seg.value)"
             >{{ seg.value }}</a>
             <template v-else>{{ seg.value }}</template>
           </template>

--- a/src/components/ElicitationDialog.vue
+++ b/src/components/ElicitationDialog.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import type { ElicitationRequest, ElicitationAction } from '../lib/types';
+
+defineProps<{
+  elicitation: ElicitationRequest;
+}>();
+
+const emit = defineEmits<{
+  (e: 'respond', action: ElicitationAction): void;
+}>();
+
+/**
+ * Split text into plain-text and URL segments so any URL embedded in the
+ * elicitation message renders as a clickable link. Mirrors the helper in
+ * AuthMethodDialog.
+ */
+type Segment = { type: 'text'; value: string } | { type: 'link'; value: string };
+const URL_RE = /(https?:\/\/[^\s]+)/g;
+
+function toSegments(text: string): Segment[] {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0];
+    const start = match.index ?? 0;
+    if (start > lastIndex) segments.push({ type: 'text', value: text.slice(lastIndex, start) });
+    segments.push({ type: 'link', value: url });
+    lastIndex = start + url.length;
+  }
+  if (lastIndex < text.length) segments.push({ type: 'text', value: text.slice(lastIndex) });
+  return segments;
+}
+
+/** Open the authorization URL in a new tab without dismissing the dialog. */
+function openUrl(url: string) {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+</script>
+
+<template>
+  <div class="elicit-overlay" @click.self="emit('respond', 'cancel')">
+    <div class="elicit-dialog">
+      <div class="dialog-header">
+        <h3>Authorization Required</h3>
+        <button class="close-btn" title="Cancel" @click="emit('respond', 'cancel')">✕</button>
+      </div>
+
+      <div class="dialog-content">
+        <p class="message">
+          <template v-for="(seg, i) in toSegments(elicitation.message)" :key="i">
+            <a
+              v-if="seg.type === 'link'"
+              :href="seg.value"
+              class="msg-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >{{ seg.value }}</a>
+            <template v-else>{{ seg.value }}</template>
+          </template>
+        </p>
+
+        <button class="open-url-btn" @click="openUrl(elicitation.url)">
+          Open authorization page ↗
+        </button>
+
+        <p class="hint">
+          Authorize in the page that opens; the turn continues automatically
+          once it's done. If it doesn't, use <strong>I've authorized</strong>.
+        </p>
+      </div>
+
+      <div class="dialog-footer">
+        <button class="decline-btn" @click="emit('respond', 'decline')">Decline</button>
+        <button class="accept-btn" @click="emit('respond', 'accept')">I've authorized</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.elicit-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.elicit-dialog {
+  background: var(--bg-main);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 440px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dialog-header h3 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.close-btn {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  padding: 0.25rem;
+}
+
+.close-btn:hover {
+  color: var(--text-primary);
+}
+
+.dialog-content {
+  padding: 1.25rem;
+}
+
+.message {
+  margin: 0 0 1rem 0;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.msg-link {
+  color: var(--bg-primary);
+  text-decoration: underline;
+}
+
+.msg-link:hover {
+  text-decoration: none;
+}
+
+.open-url-btn {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--bg-primary);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.open-url-btn:hover {
+  opacity: 0.9;
+}
+
+.hint {
+  margin: 0.75rem 0 0 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.dialog-footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.decline-btn,
+.accept-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.decline-btn {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.decline-btn:hover {
+  background: var(--bg-hover);
+}
+
+.accept-btn {
+  border: 1px solid var(--bg-primary);
+  background: var(--bg-primary);
+  color: #fff;
+}
+
+.accept-btn:hover {
+  opacity: 0.9;
+}
+</style>

--- a/src/lib/acp-bridge.ts
+++ b/src/lib/acp-bridge.ts
@@ -22,11 +22,20 @@ import type {
   CancelNotification,
   AuthenticateRequest,
   AuthenticateResponse,
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  CompleteElicitationNotification,
 } from '@agentclientprotocol/sdk';
 import { readTextFile as hostReadTextFile, writeTextFile as hostWriteTextFile } from './host';
 import type { AcpTransport, Unsubscribe } from './transport/types';
 import { createTransport } from './transport';
-import type { AgentConfig, AgentInstance, PermissionRequest as LocalPermissionRequest } from './types';
+import type {
+  AgentConfig,
+  AgentInstance,
+  PermissionRequest as LocalPermissionRequest,
+  ElicitationRequest as LocalElicitationRequest,
+  ElicitationAction,
+} from './types';
 import { hasLocalFs } from './platform';
 import { ref, type Ref } from 'vue';
 import { useTrafficStore } from '../stores/traffic';
@@ -65,6 +74,13 @@ export class AcpClientBridge implements Client {
   // Permission request handling
   public pendingPermissionRequest: Ref<LocalPermissionRequest | null> = ref(null);
   private permissionResolver: PermissionResolver | null = null;
+
+  // Elicitation (URL mode) request handling. `elicitationResolver` resolves
+  // the outstanding `elicitation/create` request; it is answered either by the
+  // user (accept/decline/cancel) or automatically when the agent sends
+  // `elicitation/complete` for the same id.
+  public pendingElicitation: Ref<LocalElicitationRequest | null> = ref(null);
+  private elicitationResolver: ((response: CreateElicitationResponse) => void) | null = null;
 
   // Session update callback
   public onSessionUpdate: ((notification: SessionNotification) => void) | null = null;
@@ -220,6 +236,9 @@ export class AcpClientBridge implements Client {
         case 'session/request_permission':
           result = await this.requestPermission(params as RequestPermissionRequest);
           break;
+        case 'elicitation/create':
+          result = await this.createElicitation(params as CreateElicitationRequest);
+          break;
         default:
           error = { code: JSONRPC_METHOD_NOT_FOUND, message: `Method not found: ${method}` };
       }
@@ -251,6 +270,8 @@ export class AcpClientBridge implements Client {
       if (this.onSessionUpdate) {
         this.onSessionUpdate(params as SessionNotification);
       }
+    } else if (method === 'elicitation/complete') {
+      this.completeElicitation(params as CompleteElicitationNotification);
     }
   }
 
@@ -399,6 +420,59 @@ export class AcpClientBridge implements Client {
       });
       this.permissionResolver = null;
       this.pendingPermissionRequest.value = null;
+    }
+  }
+
+  /**
+   * Handle a server→client `elicitation/create`. Only URL mode is supported
+   * (we advertise `clientCapabilities.elicitation.url`); any other mode is
+   * declined so the agent gets a prompt answer instead of hanging. For URL
+   * mode we surface a dialog and leave the request pending until the user
+   * acts or the agent sends `elicitation/complete`.
+   */
+  async createElicitation(
+    params: CreateElicitationRequest
+  ): Promise<CreateElicitationResponse> {
+    if (params.mode !== 'url') {
+      return { action: 'decline' };
+    }
+    // Defensive field access: `params` is a discriminated union and we handle
+    // the wire type directly rather than importing the SDK's runtime guards.
+    const url = (params as { url?: unknown }).url;
+    const elicitationId = (params as { elicitationId?: unknown }).elicitationId;
+    if (typeof url !== 'string' || typeof elicitationId !== 'string') {
+      return { action: 'decline' };
+    }
+
+    return new Promise((resolve) => {
+      this.pendingElicitation.value = {
+        elicitationId,
+        message: params.message,
+        url,
+      };
+      this.elicitationResolver = resolve;
+    });
+  }
+
+  /** Answer the outstanding elicitation with the user's chosen action. */
+  resolveElicitation(action: ElicitationAction): void {
+    if (this.elicitationResolver) {
+      this.elicitationResolver({ action } as CreateElicitationResponse);
+      this.elicitationResolver = null;
+      this.pendingElicitation.value = null;
+    }
+  }
+
+  /**
+   * Handle a server→client `elicitation/complete`: the agent detected that the
+   * URL flow finished (e.g. the user authorized the tool in their browser). If
+   * it matches the outstanding elicitation, auto-accept so the turn continues
+   * without the user having to click, and dismiss the dialog.
+   */
+  private completeElicitation(params: CompleteElicitationNotification): void {
+    const pending = this.pendingElicitation.value;
+    if (pending && pending.elicitationId === params.elicitationId) {
+      this.resolveElicitation('accept');
     }
   }
 

--- a/src/lib/acp-bridge.ts
+++ b/src/lib/acp-bridge.ts
@@ -366,8 +366,17 @@ export class AcpClientBridge implements Client {
     await this.sendRequest('session/set_mode', params);
   }
 
-  async unstable_setSessionModel(params: { sessionId: string; modelId: string }): Promise<void> {
-    await this.sendRequest('session/set_model', params);
+  /**
+   * Set a session config option (SDK 1.3.0). The model picker rides on this:
+   * the model is a `select` config option, changed via `session/set_config_option`.
+   * `unstable_` because the config-options API is not part of the stable spec.
+   */
+  async unstable_setSessionConfigOption(params: {
+    sessionId: string;
+    configId: string;
+    value: string | boolean;
+  }): Promise<void> {
+    await this.sendRequest('session/set_config_option', params);
   }
 
   async authenticate(params: AuthenticateRequest): Promise<AuthenticateResponse> {

--- a/src/lib/host/index.ts
+++ b/src/lib/host/index.ts
@@ -287,6 +287,24 @@ export async function getAppVersion(): Promise<string> {
   return v ?? FALLBACK_VERSION;
 }
 
+/**
+ * Open a URL in the user's default external browser.
+ *
+ * In a Tauri webview `window.open()` / `<a target="_blank">` do NOT reach the
+ * system browser (they no-op or try to navigate the webview), so we go through
+ * the opener plugin. On the plain web build we fall back to `window.open`,
+ * which runs synchronously here to stay inside the click's user-gesture and
+ * avoid popup blocking.
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isTauriHost()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener');
+    await openUrl(url);
+    return;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
 /** True when the host can present a native folder picker. */
 export function canPickFolder(): boolean {
   return isDesktop();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,6 +108,19 @@ export interface PermissionOption {
   optionId: string;
 }
 
+// Elicitation (URL mode) — a server→client request asking the user to visit
+// an authorization URL (e.g. a 3LO tool grant on a GlobAI agent) so a tool
+// can proceed. Mirrors the SDK's URL-mode `CreateElicitationRequest`, reduced
+// to what the dialog needs.
+export interface ElicitationRequest {
+  elicitationId: string;
+  message: string;
+  url: string;
+}
+
+/** User's response to a URL-mode elicitation. */
+export type ElicitationAction = 'accept' | 'decline' | 'cancel';
+
 // Session Modes
 export interface SessionMode {
   id: string;

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -10,7 +10,7 @@ import { AcpClientBridge, createAcpClient } from '../lib/acp-bridge';
 import { onAgentStderr, spawnAgent, killAgent } from '../lib/host';
 import { isDesktop } from '../lib/platform';
 import { useConfigStore } from './config';
-import type { SessionNotification, AuthMethod } from '@agentclientprotocol/sdk';
+import type { SessionNotification, AuthMethod, SessionConfigOption, LoadSessionResponse } from '@agentclientprotocol/sdk';
 
 const STORE_PATH = 'sessions.json';
 const PROTOCOL_VERSION = 1;
@@ -34,6 +34,82 @@ function detectPhase(line: string): string | null {
     return 'starting';
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Session config options (SDK 1.3.0) — model picker plumbing.
+//
+// SDK 1.3.0 dropped `NewSessionResponse.models` in favour of a generic
+// `configOptions` list. The model selector is the `select` option the agent
+// tags with `category: "model"`. These helpers extract it into the shape the
+// existing ModelPicker already understands. All parsing is defensive: any
+// unexpected shape yields `null`, which simply hides the picker.
+// ---------------------------------------------------------------------------
+
+interface ModelConfig {
+  /** The config option's id, sent back as `configId` on set_config_option. */
+  configId: string;
+  models: ModelInfo[];
+  currentModelId: string;
+}
+
+/** True for a string that names the model selector but not model *params*. */
+function namesModel(s: unknown): boolean {
+  return typeof s === 'string' && /model/i.test(s) && !/model[_-]?config/i.test(s);
+}
+
+/** Flatten a select option's values, tolerating both flat and grouped forms. */
+function flattenSelectOptions(options: unknown): ModelInfo[] {
+  if (!Array.isArray(options)) return [];
+  const out: ModelInfo[] = [];
+  for (const opt of options) {
+    if (!opt || typeof opt !== 'object') continue;
+    const o = opt as Record<string, unknown>;
+    if (Array.isArray(o.options)) {
+      // Grouped: recurse into the group's options.
+      out.push(...flattenSelectOptions(o.options));
+    } else if (typeof o.value === 'string') {
+      out.push({
+        modelId: o.value,
+        name: typeof o.name === 'string' ? o.name : o.value,
+        description: typeof o.description === 'string' ? o.description : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the model selector among the session's config options and map it to the
+ * ModelPicker's shape. Prefers `category: "model"`; falls back to a select
+ * whose category/id/name names "model" (excluding "model_config").
+ */
+function parseModelConfig(configOptions: SessionConfigOption[] | null | undefined): ModelConfig | null {
+  if (!Array.isArray(configOptions)) return null;
+  const selects = configOptions.filter(
+    (o): o is SessionConfigOption & { type: 'select' } =>
+      !!o && typeof o === 'object' && (o as { type?: unknown }).type === 'select'
+  );
+  const modelOpt =
+    selects.find((o) => (o as { category?: unknown }).category === 'model') ??
+    selects.find((o) => {
+      const c = o as { category?: unknown; id?: unknown; name?: unknown };
+      return namesModel(c.category) || namesModel(c.id) || namesModel(c.name);
+    });
+  if (!modelOpt) return null;
+  const opt = modelOpt as unknown as {
+    id?: unknown;
+    currentValue?: unknown;
+    options?: unknown;
+  };
+  if (typeof opt.id !== 'string') return null;
+  const models = flattenSelectOptions(opt.options);
+  if (models.length === 0) return null;
+  return {
+    configId: opt.id,
+    models,
+    currentModelId: typeof opt.currentValue === 'string' ? opt.currentValue : '',
+  };
 }
 
 export const useSessionStore = defineStore('session', () => {
@@ -84,6 +160,24 @@ export const useSessionStore = defineStore('session', () => {
   // Current ACP client
   let acpClient: AcpClientBridge | null = null;
   let store: KVStore | null = null;
+  // Config option id of the model selector (SDK 1.3.0), needed to change it.
+  let modelConfigId: string | null = null;
+
+  // Populate the model picker from a session's config options (create/resume
+  // responses and `config_option_update` notifications). Clears when there's
+  // no recognisable model selector.
+  function applyConfigOptions(configOptions: SessionConfigOption[] | null | undefined): void {
+    const modelConfig = parseModelConfig(configOptions);
+    if (modelConfig) {
+      modelConfigId = modelConfig.configId;
+      availableModels.value = modelConfig.models;
+      currentModelId.value = modelConfig.currentModelId;
+    } else {
+      modelConfigId = null;
+      availableModels.value = [];
+      currentModelId.value = '';
+    }
+  }
 
   // Computed
   const hasActiveSession = computed(() => currentSession.value !== null);
@@ -239,6 +333,14 @@ export const useSessionStore = defineStore('session', () => {
         // Agent changed the mode
         if ('modeId' in update && update.modeId) {
           currentModeId.value = update.modeId as string;
+        }
+        break;
+
+      case 'config_option_update':
+        // SDK 1.3.0: the agent pushed the full set of config options (e.g. the
+        // model changed). Re-derive the model picker from it.
+        if ('configOptions' in update) {
+          applyConfigOptions((update as { configOptions?: SessionConfigOption[] }).configOptions);
         }
         break;
 
@@ -532,12 +634,8 @@ export const useSessionStore = defineStore('session', () => {
         currentModeId.value = '';
       }
 
-      // Session models: SDK 1.3.0 dropped the dedicated `models` field on
-      // NewSessionResponse in favour of the generic `configOptions` (session
-      // config options). The model picker is disabled until it's migrated to
-      // that API; see follow-up. Clearing keeps the picker hidden.
-      availableModels.value = [];
-      currentModelId.value = '';
+      // Model picker (SDK 1.3.0): derived from the session's config options.
+      applyConfigOptions(sessionResponse.configOptions);
 
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
@@ -656,8 +754,9 @@ export const useSessionStore = defineStore('session', () => {
       toolCalls.value.clear();
 
       // Try to load existing session - may fail with auth_required
+      let loadResponse: LoadSessionResponse | undefined;
       try {
-        await acpClient.loadSession({
+        loadResponse = await acpClient.loadSession({
           sessionId: savedSession.sessionId,
           cwd: savedSession.cwd,
           mcpServers: [],
@@ -686,7 +785,7 @@ export const useSessionStore = defineStore('session', () => {
           console.log('Authentication successful:', authResponse);
 
           // Retry loading session after auth
-          await acpClient.loadSession({
+          loadResponse = await acpClient.loadSession({
             sessionId: savedSession.sessionId,
             cwd: savedSession.cwd,
             mcpServers: [],
@@ -695,6 +794,11 @@ export const useSessionStore = defineStore('session', () => {
           throw sessionError;
         }
       }
+
+      // Model picker (SDK 1.3.0): populate from the resumed session's config
+      // options if the agent returned them. Live changes still arrive via
+      // config_option_update notifications during replay.
+      applyConfigOptions(loadResponse?.configOptions);
 
       currentSession.value = savedSession;
       isConnected.value = true;
@@ -861,6 +965,7 @@ export const useSessionStore = defineStore('session', () => {
     availableCommands.value = [];
     availableModels.value = [];
     currentModelId.value = '';
+    modelConfigId = null;
   }
 
   // Delete saved session
@@ -889,13 +994,19 @@ export const useSessionStore = defineStore('session', () => {
     if (!acpClient || !currentSession.value) {
       throw new Error('No active session');
     }
-    
-    await acpClient.unstable_setSessionModel({
+    if (!modelConfigId) {
+      throw new Error('No model config option available for this session');
+    }
+
+    // SDK 1.3.0: the model is a session config option, changed via
+    // session/set_config_option (configId = the model option's id).
+    await acpClient.unstable_setSessionConfigOption({
       sessionId: currentSession.value.sessionId,
-      modelId,
+      configId: modelConfigId,
+      value: modelId,
     });
-    
-    // Optimistically update the current model
+
+    // Optimistically update; a config_option_update may confirm/override.
     currentModelId.value = modelId;
   }
 

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -4,7 +4,7 @@ import { ref, computed, watch } from 'vue';
 import { loadKvStore, type KVStore } from '../lib/host/storage';
 import { getAppVersion } from '../lib/host';
 import { trackEvent, trackError } from '../lib/telemetry';
-import type { SavedSession, ChatMessage, ToolCallInfo, PermissionRequest, SessionMode, SlashCommand, ModelInfo, AgentConfig } from '../lib/types';
+import type { SavedSession, ChatMessage, ToolCallInfo, PermissionRequest, SessionMode, SlashCommand, ModelInfo, AgentConfig, ElicitationRequest, ElicitationAction } from '../lib/types';
 import { getTransportKind } from '../lib/types';
 import { AcpClientBridge, createAcpClient } from '../lib/acp-bridge';
 import { onAgentStderr, spawnAgent, killAgent } from '../lib/host';
@@ -52,6 +52,8 @@ export const useSessionStore = defineStore('session', () => {
   const isReconnecting = ref(false);
   const error = ref<string | null>(null);
   const pendingPermission = ref<PermissionRequest | null>(null);
+  // URL-mode elicitation currently awaiting the user (or auto-completion).
+  const pendingElicitation = ref<ElicitationRequest | null>(null);
   
   // Authentication state
   const pendingAuthMethods = ref<AuthMethod[]>([]);
@@ -127,6 +129,7 @@ export const useSessionStore = defineStore('session', () => {
     isConnected.value = false;
     isLoading.value = false;
     pendingPermission.value = null;
+    pendingElicitation.value = null;
     error.value = `Connection lost: ${reason ?? 'transport closed'}`;
   }
 
@@ -388,6 +391,16 @@ export const useSessionStore = defineStore('session', () => {
         { immediate: true }
       );
 
+      // Sync bridge's pendingElicitation to the store so the UI can show the
+      // URL-mode authorization dialog.
+      watch(
+        () => acpClient?.pendingElicitation.value,
+        (newValue) => {
+          pendingElicitation.value = newValue ?? null;
+        },
+        { immediate: true }
+      );
+
       if (connectionAborted) {
         await acpClient.disconnect();
         throw new Error('Connection cancelled');
@@ -406,6 +419,12 @@ export const useSessionStore = defineStore('session', () => {
           fs: {
             readTextFile: canAccessFs,
             writeTextFile: canAccessFs,
+          },
+          // Advertise URL-mode elicitation so agents (e.g. GlobAI) can drive
+          // tool authorization (3LO) via elicitation/create instead of getting
+          // a METHOD_NOT_FOUND. `unstable_` in the SDK; wire field is `url`.
+          elicitation: {
+            url: {},
           },
         },
         clientInfo: {
@@ -513,18 +532,12 @@ export const useSessionStore = defineStore('session', () => {
         currentModeId.value = '';
       }
 
-      // Set up session models if available
-      if (sessionResponse.models) {
-        availableModels.value = (sessionResponse.models.availableModels || []).map(m => ({
-          modelId: m.modelId,
-          name: m.name,
-          description: m.description ?? undefined,
-        }));
-        currentModelId.value = sessionResponse.models.currentModelId || '';
-      } else {
-        availableModels.value = [];
-        currentModelId.value = '';
-      }
+      // Session models: SDK 1.3.0 dropped the dedicated `models` field on
+      // NewSessionResponse in favour of the generic `configOptions` (session
+      // config options). The model picker is disabled until it's migrated to
+      // that API; see follow-up. Clearing keeps the picker hidden.
+      availableModels.value = [];
+      currentModelId.value = '';
 
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
@@ -599,6 +612,16 @@ export const useSessionStore = defineStore('session', () => {
         { immediate: true }
       );
 
+      // Sync bridge's pendingElicitation to the store so the UI can show the
+      // URL-mode authorization dialog.
+      watch(
+        () => acpClient?.pendingElicitation.value,
+        (newValue) => {
+          pendingElicitation.value = newValue ?? null;
+        },
+        { immediate: true }
+      );
+
       // Only Tauri desktop has real filesystem access; mobile and web
       // cannot fulfil readTextFile / writeTextFile RPCs.
       const canAccessFs = isDesktop();
@@ -610,6 +633,12 @@ export const useSessionStore = defineStore('session', () => {
           fs: {
             readTextFile: canAccessFs,
             writeTextFile: canAccessFs,
+          },
+          // Advertise URL-mode elicitation so agents (e.g. GlobAI) can drive
+          // tool authorization (3LO) via elicitation/create instead of getting
+          // a METHOD_NOT_FOUND. `unstable_` in the SDK; wire field is `url`.
+          elicitation: {
+            url: {},
           },
         },
         clientInfo: {
@@ -794,6 +823,15 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
+  // Answer a URL-mode elicitation (accept / decline / cancel). The bridge
+  // clears its own pending ref; the watch propagates that to the store.
+  function resolveElicitation(action: ElicitationAction): void {
+    if (acpClient) {
+      acpClient.resolveElicitation(action);
+    }
+    pendingElicitation.value = null;
+  }
+
   // Disconnect current session
   async function disconnect(): Promise<void> {
     const agentName = currentSession.value?.agentName || 'unknown';
@@ -816,6 +854,8 @@ export const useSessionStore = defineStore('session', () => {
     isConnected.value = false;
     messages.value = [];
     toolCalls.value.clear();
+    pendingPermission.value = null;
+    pendingElicitation.value = null;
     availableModes.value = [];
     currentModeId.value = '';
     availableCommands.value = [];
@@ -927,6 +967,7 @@ export const useSessionStore = defineStore('session', () => {
     isReconnecting,
     error,
     pendingPermission,
+    pendingElicitation,
     pendingAuthMethods,
     pendingAuthAgentName,
     availableModes,
@@ -953,6 +994,7 @@ export const useSessionStore = defineStore('session', () => {
     cancelConnection,
     resolvePermission,
     cancelPermission,
+    resolveElicitation,
     selectAuthMethod,
     cancelAuthSelection,
     disconnect,


### PR DESCRIPTION
## Motivation

Agents built on `@agentclientprotocol/sdk` 1.3.0 (e.g. GlobAI) can request tool authorization mid-turn via `elicitation/create` (URL mode) — for example a 3LO grant. This client was on SDK 0.13.1, which has no elicitation, so it replied `METHOD_NOT_FOUND` and the flow never completed. This adds client-side support for URL-mode elicitation, bumps the SDK, and keeps everything else working across the bump.

## Expected flow

During a turn, if a tool needs authorization the agent sends `elicitation/create` (URL mode) with a message and a login URL. The client shows a dialog, the user opens the URL and authorizes, and the turn continues on its own — without re-typing the prompt.

## Changes

1. **Bump `@agentclientprotocol/sdk` 0.13.1 → 1.3.0** (matches the server SDK). All existing flows (WebSocket connect, *Authentication Required*, permissions, modes) are unchanged.
2. **Advertise the capability** on initialize: `clientCapabilities.elicitation = { url: {} }` (`unstable_` in the SDK).
3. **Handle `elicitation/create` (URL mode)** — a new `ElicitationDialog` shows the message and a button to open the authorization URL in a new tab; the user responds `{ action: "accept" | "decline" | "cancel" }`. Non-URL modes are declined.
4. **Handle `elicitation/complete`** — when the agent signals the URL flow finished, the client auto-accepts the matching elicitation so the turn continues without the user clicking.
5. **Model picker migrated to `configOptions`** (second commit). The bump removed `NewSessionResponse.models`; the model is now a `select` session config option (`category: "model"`). The picker now reads from `configOptions`, changes the model via `session/set_config_option`, and refreshes on `config_option_update`. Defensive parsing hides the picker on any unexpected shape. No regression from the bump.

## Testing

- `npx vue-tsc --noEmit` and `npm run build:web` pass.
- Manual: against a GlobAI agent whose tool needs a 3LO grant, prompting it surfaces the elicitation dialog; authorizing in the opened page lets the turn continue with no re-prompt; the model picker lists and switches models.
