### PR TITLE
feat(terminal): implement ACP terminal capability (desktop)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "acp-ui",
-  "version": "0.1.0",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acp-ui",
-      "version": "0.1.0",
+      "version": "0.1.16",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.13.1",
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@microsoft/applicationinsights-web": "^3.3.11",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -1381,7 +1381,6 @@
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2071,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -2272,7 +2270,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2331,7 +2328,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2413,7 +2409,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.13.1",
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@microsoft/applicationinsights-web": "^3.3.11",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,10 @@
 mod agent;
 mod config;
+mod terminal;
 
 use agent::{AgentInstance, AgentManager};
 use config::{AgentConfig, AgentTransport, AgentsConfig, ConfigManager};
+use terminal::{EnvVar, TerminalExitStatus, TerminalManager, TerminalOutput};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager, State};
@@ -10,6 +12,7 @@ use tauri::{AppHandle, Manager, State};
 struct AppState {
     config_manager: Arc<RwLock<Option<ConfigManager>>>,
     agent_manager: AgentManager,
+    terminal_manager: TerminalManager,
 }
 
 #[tauri::command]
@@ -200,6 +203,47 @@ fn build_agent_config(
 }
 
 #[tauri::command]
+fn terminal_create(
+    command: String,
+    args: Option<Vec<String>>,
+    env: Option<Vec<EnvVar>>,
+    cwd: Option<String>,
+    output_byte_limit: Option<usize>,
+    state: State<AppState>,
+) -> Result<String, String> {
+    state.terminal_manager.create(
+        command,
+        args.unwrap_or_default(),
+        env.unwrap_or_default(),
+        cwd,
+        output_byte_limit,
+    )
+}
+
+#[tauri::command]
+fn terminal_output(terminal_id: String, state: State<AppState>) -> Result<TerminalOutput, String> {
+    state.terminal_manager.output(&terminal_id)
+}
+
+#[tauri::command]
+fn terminal_wait_for_exit(
+    terminal_id: String,
+    state: State<AppState>,
+) -> Result<TerminalExitStatus, String> {
+    state.terminal_manager.wait_for_exit(&terminal_id)
+}
+
+#[tauri::command]
+fn terminal_kill(terminal_id: String, state: State<AppState>) -> Result<(), String> {
+    state.terminal_manager.kill(&terminal_id)
+}
+
+#[tauri::command]
+fn terminal_release(terminal_id: String, state: State<AppState>) -> Result<(), String> {
+    state.terminal_manager.release(&terminal_id)
+}
+
+#[tauri::command]
 fn get_machine_id() -> Result<String, String> {
     // `machine-uid` is desktop-only (no support for iOS / Android). Telemetry
     // on mobile falls back to an anonymous id (the frontend handles a failure
@@ -219,6 +263,7 @@ pub fn run() {
     let app_state = AppState {
         config_manager: Arc::new(RwLock::new(None)),
         agent_manager: AgentManager::new(),
+        terminal_manager: TerminalManager::new(),
     };
 
     tauri::Builder::default()
@@ -254,6 +299,11 @@ pub fn run() {
             add_agent,
             remove_agent,
             update_agent,
+            terminal_create,
+            terminal_output,
+            terminal_wait_for_exit,
+            terminal_kill,
+            terminal_release,
             get_machine_id
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,0 +1,371 @@
+// Terminal capability (ACP `terminal/*`) — desktop only.
+//
+// Lets an agent run commands on the user's machine and read their output,
+// mirroring the ACP terminal RPCs. Processes are spawned through the user's
+// login shell (like `agent.rs`) so PATH resolves tools such as `git`/`node`.
+//
+// SECURITY: this grants the connected agent arbitrary command execution on the
+// user's machine. It is gated to desktop and to clients that advertise the
+// `terminal` capability; consider a user-facing opt-in before exposing it to
+// untrusted agents.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(desktop)]
+use std::collections::HashMap;
+#[cfg(desktop)]
+use std::io::{BufReader, Read};
+#[cfg(desktop)]
+use std::process::{Child, Command, Stdio};
+#[cfg(desktop)]
+use std::sync::{Arc, Condvar, Mutex};
+#[cfg(desktop)]
+use std::thread;
+#[cfg(desktop)]
+use std::time::Duration;
+#[cfg(desktop)]
+use uuid::Uuid;
+
+#[cfg(all(desktop, target_os = "windows"))]
+use std::os::windows::process::CommandExt;
+#[cfg(all(desktop, not(target_os = "windows")))]
+use shell_escape;
+
+/// One environment variable for a spawned terminal (ACP `EnvVariable`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvVar {
+    pub name: String,
+    pub value: String,
+}
+
+/// Exit status of a terminal process (ACP `TerminalExitStatus`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalExitStatus {
+    #[serde(rename = "exitCode", skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<String>,
+}
+
+/// Response for `terminal/output` (ACP `TerminalOutputResponse`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerminalOutput {
+    pub output: String,
+    pub truncated: bool,
+    #[serde(rename = "exitStatus", skip_serializing_if = "Option::is_none")]
+    pub exit_status: Option<TerminalExitStatus>,
+}
+
+#[cfg(desktop)]
+struct BufState {
+    data: Vec<u8>,
+    truncated: bool,
+    limit: Option<usize>,
+}
+
+#[cfg(desktop)]
+struct Shared {
+    buffer: Mutex<BufState>,
+    exit: Mutex<Option<TerminalExitStatus>>,
+    exit_cv: Condvar,
+}
+
+#[cfg(desktop)]
+struct RunningTerminal {
+    child: Arc<Mutex<Child>>,
+    shared: Arc<Shared>,
+}
+
+#[cfg(desktop)]
+pub struct TerminalManager {
+    terminals: Arc<Mutex<HashMap<String, RunningTerminal>>>,
+}
+
+#[cfg(not(desktop))]
+pub struct TerminalManager {
+    _phantom: std::marker::PhantomData<()>,
+}
+
+#[cfg(desktop)]
+fn append_output(shared: &Shared, chunk: &[u8]) {
+    let mut b = shared.buffer.lock().unwrap();
+    b.data.extend_from_slice(chunk);
+    if let Some(limit) = b.limit {
+        if b.data.len() > limit {
+            // Truncate from the beginning to stay within the byte limit, then
+            // advance to the next UTF-8 char boundary so `output` stays valid.
+            let excess = b.data.len() - limit;
+            b.data.drain(0..excess);
+            let mut start = 0;
+            while start < b.data.len() && (b.data[start] & 0xC0) == 0x80 {
+                start += 1;
+            }
+            if start > 0 {
+                b.data.drain(0..start);
+            }
+            b.truncated = true;
+        }
+    }
+}
+
+#[cfg(desktop)]
+fn to_exit_status(st: std::process::ExitStatus) -> TerminalExitStatus {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        TerminalExitStatus {
+            exit_code: st.code(),
+            signal: st.signal().map(|s| s.to_string()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        TerminalExitStatus {
+            exit_code: st.code(),
+            signal: None,
+        }
+    }
+}
+
+#[cfg(desktop)]
+impl TerminalManager {
+    pub fn new() -> Self {
+        Self {
+            terminals: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn create(
+        &self,
+        command: String,
+        args: Vec<String>,
+        env: Vec<EnvVar>,
+        cwd: Option<String>,
+        output_byte_limit: Option<usize>,
+    ) -> Result<String, String> {
+        // Build the child through the user's shell so PATH resolves like a real
+        // terminal (mirrors agent.rs). Command + args are quoted into one line.
+        #[cfg(target_os = "windows")]
+        let mut cmd = {
+            let mut c = Command::new("cmd");
+            c.arg("/C").arg(&command).args(&args);
+            c.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            c
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let mut cmd = {
+            use std::borrow::Cow;
+            let escaped_command = shell_escape::escape(Cow::Borrowed(command.as_str()));
+            let shell_command = if args.is_empty() {
+                escaped_command.to_string()
+            } else {
+                let quoted: Vec<String> = args
+                    .iter()
+                    .map(|a| shell_escape::escape(Cow::Borrowed(a.as_str())).to_string())
+                    .collect();
+                format!("{} {}", escaped_command, quoted.join(" "))
+            };
+
+            let user_shell = std::env::var("SHELL").unwrap_or_default();
+            let shell_name = std::path::Path::new(&user_shell)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
+            let (shell, use_login) = match shell_name {
+                "bash" | "zsh" | "ksh" => (user_shell.as_str(), true),
+                "fish" => (user_shell.as_str(), false),
+                _ => {
+                    if std::path::Path::new("/bin/bash").exists() {
+                        ("/bin/bash", true)
+                    } else if std::path::Path::new("/usr/bin/bash").exists() {
+                        ("/usr/bin/bash", true)
+                    } else {
+                        ("/bin/sh", false)
+                    }
+                }
+            };
+            let mut c = Command::new(shell);
+            if use_login {
+                c.arg("-l");
+            }
+            c.arg("-c").arg(&shell_command);
+            c
+        };
+
+        for e in &env {
+            cmd.env(&e.name, &e.value);
+        }
+        if let Some(dir) = &cwd {
+            cmd.current_dir(dir);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn terminal: {}", e))?;
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let shared = Arc::new(Shared {
+            buffer: Mutex::new(BufState {
+                data: Vec::new(),
+                truncated: false,
+                limit: output_byte_limit,
+            }),
+            exit: Mutex::new(None),
+            exit_cv: Condvar::new(),
+        });
+
+        // Reader threads: combine stdout + stderr into the single output buffer.
+        if let Some(out) = stdout {
+            let sh = Arc::clone(&shared);
+            thread::spawn(move || {
+                let mut reader = BufReader::new(out);
+                let mut buf = [0u8; 4096];
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => append_output(&sh, &buf[..n]),
+                    }
+                }
+            });
+        }
+        if let Some(err) = stderr {
+            let sh = Arc::clone(&shared);
+            thread::spawn(move || {
+                let mut reader = BufReader::new(err);
+                let mut buf = [0u8; 4096];
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => append_output(&sh, &buf[..n]),
+                    }
+                }
+            });
+        }
+
+        let child = Arc::new(Mutex::new(child));
+
+        // Waiter thread: poll try_wait so kill() can still lock the child.
+        let waiter_child = Arc::clone(&child);
+        let waiter_shared = Arc::clone(&shared);
+        thread::spawn(move || loop {
+            let status = { waiter_child.lock().unwrap().try_wait() };
+            match status {
+                Ok(Some(st)) => {
+                    *waiter_shared.exit.lock().unwrap() = Some(to_exit_status(st));
+                    waiter_shared.exit_cv.notify_all();
+                    break;
+                }
+                Ok(None) => thread::sleep(Duration::from_millis(100)),
+                Err(_) => {
+                    *waiter_shared.exit.lock().unwrap() = Some(TerminalExitStatus {
+                        exit_code: None,
+                        signal: None,
+                    });
+                    waiter_shared.exit_cv.notify_all();
+                    break;
+                }
+            }
+        });
+
+        let id = Uuid::new_v4().to_string();
+        self.terminals
+            .lock()
+            .unwrap()
+            .insert(id.clone(), RunningTerminal { child, shared });
+        Ok(id)
+    }
+
+    fn shared_for(&self, id: &str) -> Result<Arc<Shared>, String> {
+        self.terminals
+            .lock()
+            .unwrap()
+            .get(id)
+            .map(|t| Arc::clone(&t.shared))
+            .ok_or_else(|| format!("Terminal not found: {}", id))
+    }
+
+    pub fn output(&self, id: &str) -> Result<TerminalOutput, String> {
+        let shared = self.shared_for(id)?;
+        let b = shared.buffer.lock().unwrap();
+        let output = String::from_utf8_lossy(&b.data).to_string();
+        let truncated = b.truncated;
+        drop(b);
+        let exit_status = shared.exit.lock().unwrap().clone();
+        Ok(TerminalOutput {
+            output,
+            truncated,
+            exit_status,
+        })
+    }
+
+    pub fn wait_for_exit(&self, id: &str) -> Result<TerminalExitStatus, String> {
+        let shared = self.shared_for(id)?;
+        let mut ex = shared.exit.lock().unwrap();
+        while ex.is_none() {
+            ex = shared.exit_cv.wait(ex).unwrap();
+        }
+        Ok(ex.clone().unwrap())
+    }
+
+    pub fn kill(&self, id: &str) -> Result<(), String> {
+        if let Some(t) = self.terminals.lock().unwrap().get(id) {
+            let _ = t.child.lock().unwrap().kill();
+        }
+        Ok(())
+    }
+
+    pub fn release(&self, id: &str) -> Result<(), String> {
+        if let Some(t) = self.terminals.lock().unwrap().remove(id) {
+            let _ = t.child.lock().unwrap().kill();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(desktop))]
+impl TerminalManager {
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn create(
+        &self,
+        _command: String,
+        _args: Vec<String>,
+        _env: Vec<EnvVar>,
+        _cwd: Option<String>,
+        _output_byte_limit: Option<usize>,
+    ) -> Result<String, String> {
+        Err("terminal is not supported on this platform".to_string())
+    }
+
+    pub fn output(&self, _id: &str) -> Result<TerminalOutput, String> {
+        Err("terminal is not supported on this platform".to_string())
+    }
+
+    pub fn wait_for_exit(&self, _id: &str) -> Result<TerminalExitStatus, String> {
+        Err("terminal is not supported on this platform".to_string())
+    }
+
+    pub fn kill(&self, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    pub fn release(&self, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+impl Default for TerminalManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import ChatView from './components/ChatView.vue';
 import PermissionDialog from './components/PermissionDialog.vue';
 import SettingsView from './components/SettingsView.vue';
 import AuthMethodDialog from './components/AuthMethodDialog.vue';
+import ElicitationDialog from './components/ElicitationDialog.vue';
 import TrafficMonitor from './components/TrafficMonitor.vue';
 import StartupProgress from './components/StartupProgress.vue';
 import type { SavedSession } from './lib/types';
@@ -95,6 +96,9 @@ async function handleManualReconnect() {
 
 // Watch for permission requests from session store
 const pendingPermission = computed(() => sessionStore.pendingPermission);
+
+// Watch for URL-mode elicitation requests (tool authorization)
+const pendingElicitation = computed(() => sessionStore.pendingElicitation);
 
 // Watch for auth method selection requests
 const pendingAuthMethods = computed(() => sessionStore.pendingAuthMethods);
@@ -226,6 +230,10 @@ function handleAuthMethodSelect(methodId: string) {
 
 function handleAuthMethodCancel() {
   sessionStore.cancelAuthSelection();
+}
+
+function handleElicitationRespond(action: 'accept' | 'decline' | 'cancel') {
+  sessionStore.resolveElicitation(action);
 }
 
 function toggleSidebar() {
@@ -446,12 +454,19 @@ function clearError() {
     />
 
     <!-- Auth Method Dialog -->
-    <AuthMethodDialog 
+    <AuthMethodDialog
       v-if="pendingAuthMethods.length > 0"
       :auth-methods="pendingAuthMethods"
       :agent-name="pendingAuthAgentName"
       @select="handleAuthMethodSelect"
       @cancel="handleAuthMethodCancel"
+    />
+
+    <!-- Elicitation Dialog (URL-mode tool authorization) -->
+    <ElicitationDialog
+      v-if="pendingElicitation"
+      :elicitation="pendingElicitation"
+      @respond="handleElicitationRespond"
     />
 
     <!-- Settings -->

--- a/src/components/ElicitationDialog.vue
+++ b/src/components/ElicitationDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ElicitationRequest, ElicitationAction } from '../lib/types';
+import { openExternalUrl } from '../lib/host';
 
 defineProps<{
   elicitation: ElicitationRequest;
@@ -31,9 +32,10 @@ function toSegments(text: string): Segment[] {
   return segments;
 }
 
-/** Open the authorization URL in a new tab without dismissing the dialog. */
+/** Open the authorization URL in the system browser (Tauri) or a new tab
+ * (web), without dismissing the dialog. */
 function openUrl(url: string) {
-  window.open(url, '_blank', 'noopener,noreferrer');
+  void openExternalUrl(url);
 }
 </script>
 
@@ -54,6 +56,7 @@ function openUrl(url: string) {
               class="msg-link"
               target="_blank"
               rel="noopener noreferrer"
+              @click.prevent="openUrl(seg.value)"
             >{{ seg.value }}</a>
             <template v-else>{{ seg.value }}</template>
           </template>

--- a/src/components/ElicitationDialog.vue
+++ b/src/components/ElicitationDialog.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import type { ElicitationRequest, ElicitationAction } from '../lib/types';
+
+defineProps<{
+  elicitation: ElicitationRequest;
+}>();
+
+const emit = defineEmits<{
+  (e: 'respond', action: ElicitationAction): void;
+}>();
+
+/**
+ * Split text into plain-text and URL segments so any URL embedded in the
+ * elicitation message renders as a clickable link. Mirrors the helper in
+ * AuthMethodDialog.
+ */
+type Segment = { type: 'text'; value: string } | { type: 'link'; value: string };
+const URL_RE = /(https?:\/\/[^\s]+)/g;
+
+function toSegments(text: string): Segment[] {
+  const segments: Segment[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0];
+    const start = match.index ?? 0;
+    if (start > lastIndex) segments.push({ type: 'text', value: text.slice(lastIndex, start) });
+    segments.push({ type: 'link', value: url });
+    lastIndex = start + url.length;
+  }
+  if (lastIndex < text.length) segments.push({ type: 'text', value: text.slice(lastIndex) });
+  return segments;
+}
+
+/** Open the authorization URL in a new tab without dismissing the dialog. */
+function openUrl(url: string) {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+</script>
+
+<template>
+  <div class="elicit-overlay" @click.self="emit('respond', 'cancel')">
+    <div class="elicit-dialog">
+      <div class="dialog-header">
+        <h3>Authorization Required</h3>
+        <button class="close-btn" title="Cancel" @click="emit('respond', 'cancel')">✕</button>
+      </div>
+
+      <div class="dialog-content">
+        <p class="message">
+          <template v-for="(seg, i) in toSegments(elicitation.message)" :key="i">
+            <a
+              v-if="seg.type === 'link'"
+              :href="seg.value"
+              class="msg-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >{{ seg.value }}</a>
+            <template v-else>{{ seg.value }}</template>
+          </template>
+        </p>
+
+        <button class="open-url-btn" @click="openUrl(elicitation.url)">
+          Open authorization page ↗
+        </button>
+
+        <p class="hint">
+          Authorize in the page that opens; the turn continues automatically
+          once it's done. If it doesn't, use <strong>I've authorized</strong>.
+        </p>
+      </div>
+
+      <div class="dialog-footer">
+        <button class="decline-btn" @click="emit('respond', 'decline')">Decline</button>
+        <button class="accept-btn" @click="emit('respond', 'accept')">I've authorized</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.elicit-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.elicit-dialog {
+  background: var(--bg-main);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 440px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dialog-header h3 {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.close-btn {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  padding: 0.25rem;
+}
+
+.close-btn:hover {
+  color: var(--text-primary);
+}
+
+.dialog-content {
+  padding: 1.25rem;
+}
+
+.message {
+  margin: 0 0 1rem 0;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.msg-link {
+  color: var(--bg-primary);
+  text-decoration: underline;
+}
+
+.msg-link:hover {
+  text-decoration: none;
+}
+
+.open-url-btn {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--bg-primary);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.open-url-btn:hover {
+  opacity: 0.9;
+}
+
+.hint {
+  margin: 0.75rem 0 0 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.dialog-footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.decline-btn,
+.accept-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.decline-btn {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.decline-btn:hover {
+  background: var(--bg-hover);
+}
+
+.accept-btn {
+  border: 1px solid var(--bg-primary);
+  background: var(--bg-primary);
+  color: #fff;
+}
+
+.accept-btn:hover {
+  opacity: 0.9;
+}
+</style>

--- a/src/lib/acp-bridge.ts
+++ b/src/lib/acp-bridge.ts
@@ -22,11 +22,20 @@ import type {
   CancelNotification,
   AuthenticateRequest,
   AuthenticateResponse,
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  CompleteElicitationNotification,
 } from '@agentclientprotocol/sdk';
 import { readTextFile as hostReadTextFile, writeTextFile as hostWriteTextFile } from './host';
 import type { AcpTransport, Unsubscribe } from './transport/types';
 import { createTransport } from './transport';
-import type { AgentConfig, AgentInstance, PermissionRequest as LocalPermissionRequest } from './types';
+import type {
+  AgentConfig,
+  AgentInstance,
+  PermissionRequest as LocalPermissionRequest,
+  ElicitationRequest as LocalElicitationRequest,
+  ElicitationAction,
+} from './types';
 import { hasLocalFs } from './platform';
 import { ref, type Ref } from 'vue';
 import { useTrafficStore } from '../stores/traffic';
@@ -65,6 +74,13 @@ export class AcpClientBridge implements Client {
   // Permission request handling
   public pendingPermissionRequest: Ref<LocalPermissionRequest | null> = ref(null);
   private permissionResolver: PermissionResolver | null = null;
+
+  // Elicitation (URL mode) request handling. `elicitationResolver` resolves
+  // the outstanding `elicitation/create` request; it is answered either by the
+  // user (accept/decline/cancel) or automatically when the agent sends
+  // `elicitation/complete` for the same id.
+  public pendingElicitation: Ref<LocalElicitationRequest | null> = ref(null);
+  private elicitationResolver: ((response: CreateElicitationResponse) => void) | null = null;
 
   // Session update callback
   public onSessionUpdate: ((notification: SessionNotification) => void) | null = null;
@@ -220,6 +236,9 @@ export class AcpClientBridge implements Client {
         case 'session/request_permission':
           result = await this.requestPermission(params as RequestPermissionRequest);
           break;
+        case 'elicitation/create':
+          result = await this.createElicitation(params as CreateElicitationRequest);
+          break;
         default:
           error = { code: JSONRPC_METHOD_NOT_FOUND, message: `Method not found: ${method}` };
       }
@@ -251,6 +270,8 @@ export class AcpClientBridge implements Client {
       if (this.onSessionUpdate) {
         this.onSessionUpdate(params as SessionNotification);
       }
+    } else if (method === 'elicitation/complete') {
+      this.completeElicitation(params as CompleteElicitationNotification);
     }
   }
 
@@ -399,6 +420,59 @@ export class AcpClientBridge implements Client {
       });
       this.permissionResolver = null;
       this.pendingPermissionRequest.value = null;
+    }
+  }
+
+  /**
+   * Handle a server→client `elicitation/create`. Only URL mode is supported
+   * (we advertise `clientCapabilities.elicitation.url`); any other mode is
+   * declined so the agent gets a prompt answer instead of hanging. For URL
+   * mode we surface a dialog and leave the request pending until the user
+   * acts or the agent sends `elicitation/complete`.
+   */
+  async createElicitation(
+    params: CreateElicitationRequest
+  ): Promise<CreateElicitationResponse> {
+    if (params.mode !== 'url') {
+      return { action: 'decline' };
+    }
+    // Defensive field access: `params` is a discriminated union and we handle
+    // the wire type directly rather than importing the SDK's runtime guards.
+    const url = (params as { url?: unknown }).url;
+    const elicitationId = (params as { elicitationId?: unknown }).elicitationId;
+    if (typeof url !== 'string' || typeof elicitationId !== 'string') {
+      return { action: 'decline' };
+    }
+
+    return new Promise((resolve) => {
+      this.pendingElicitation.value = {
+        elicitationId,
+        message: params.message,
+        url,
+      };
+      this.elicitationResolver = resolve;
+    });
+  }
+
+  /** Answer the outstanding elicitation with the user's chosen action. */
+  resolveElicitation(action: ElicitationAction): void {
+    if (this.elicitationResolver) {
+      this.elicitationResolver({ action } as CreateElicitationResponse);
+      this.elicitationResolver = null;
+      this.pendingElicitation.value = null;
+    }
+  }
+
+  /**
+   * Handle a server→client `elicitation/complete`: the agent detected that the
+   * URL flow finished (e.g. the user authorized the tool in their browser). If
+   * it matches the outstanding elicitation, auto-accept so the turn continues
+   * without the user having to click, and dismiss the dialog.
+   */
+  private completeElicitation(params: CompleteElicitationNotification): void {
+    const pending = this.pendingElicitation.value;
+    if (pending && pending.elicitationId === params.elicitationId) {
+      this.resolveElicitation('accept');
     }
   }
 

--- a/src/lib/acp-bridge.ts
+++ b/src/lib/acp-bridge.ts
@@ -366,8 +366,17 @@ export class AcpClientBridge implements Client {
     await this.sendRequest('session/set_mode', params);
   }
 
-  async unstable_setSessionModel(params: { sessionId: string; modelId: string }): Promise<void> {
-    await this.sendRequest('session/set_model', params);
+  /**
+   * Set a session config option (SDK 1.3.0). The model picker rides on this:
+   * the model is a `select` config option, changed via `session/set_config_option`.
+   * `unstable_` because the config-options API is not part of the stable spec.
+   */
+  async unstable_setSessionConfigOption(params: {
+    sessionId: string;
+    configId: string;
+    value: string | boolean;
+  }): Promise<void> {
+    await this.sendRequest('session/set_config_option', params);
   }
 
   async authenticate(params: AuthenticateRequest): Promise<AuthenticateResponse> {

--- a/src/lib/acp-bridge.ts
+++ b/src/lib/acp-bridge.ts
@@ -25,8 +25,26 @@ import type {
   CreateElicitationRequest,
   CreateElicitationResponse,
   CompleteElicitationNotification,
+  CreateTerminalRequest,
+  CreateTerminalResponse,
+  TerminalOutputRequest,
+  TerminalOutputResponse,
+  WaitForTerminalExitRequest,
+  WaitForTerminalExitResponse,
+  KillTerminalRequest,
+  KillTerminalResponse,
+  ReleaseTerminalRequest,
+  ReleaseTerminalResponse,
 } from '@agentclientprotocol/sdk';
-import { readTextFile as hostReadTextFile, writeTextFile as hostWriteTextFile } from './host';
+import {
+  readTextFile as hostReadTextFile,
+  writeTextFile as hostWriteTextFile,
+  terminalCreate,
+  terminalOutput,
+  terminalWaitForExit,
+  terminalKill,
+  terminalRelease,
+} from './host';
 import type { AcpTransport, Unsubscribe } from './transport/types';
 import { createTransport } from './transport';
 import type {
@@ -64,6 +82,9 @@ export class AcpClientBridge implements Client {
    * error so a misbehaving agent can't hang waiting for a response.
    */
   private fsAvailable: boolean;
+  /** Terminal RPCs (`terminal/*`) require a desktop subprocess, so they are
+   * only handled on Tauri desktop; elsewhere they respond method-not-found. */
+  private terminalAvailable: boolean;
   private messageResolvers: Map<number, (response: unknown) => void> = new Map();
   private messageRejecters: Map<number, (error: Error) => void> = new Map();
   private pendingMethods: Map<number, string> = new Map(); // Track method names for responses
@@ -93,6 +114,7 @@ export class AcpClientBridge implements Client {
     // Default: fs is available iff we are on Tauri desktop. Callers (e.g.
     // remote agents that trust the host fs) can override.
     this.fsAvailable = options?.fsAvailable ?? hasLocalFs();
+    this.terminalAvailable = hasLocalFs();
     this.unlistenMessage = this.transport.onMessage((msg) => this.handleMessage(msg));
     this.unlistenClose = this.transport.onClose((reason) => {
       // Reject all in-flight requests so callers stop hanging.
@@ -238,6 +260,17 @@ export class AcpClientBridge implements Client {
           break;
         case 'elicitation/create':
           result = await this.createElicitation(params as CreateElicitationRequest);
+          break;
+        case 'terminal/create':
+        case 'terminal/output':
+        case 'terminal/wait_for_exit':
+        case 'terminal/kill':
+        case 'terminal/release':
+          if (!this.terminalAvailable) {
+            error = { code: JSONRPC_METHOD_NOT_FOUND, message: `${method} not available on this client` };
+          } else {
+            result = await this.handleTerminal(method, params);
+          }
           break;
         default:
           error = { code: JSONRPC_METHOD_NOT_FOUND, message: `Method not found: ${method}` };
@@ -482,6 +515,56 @@ export class AcpClientBridge implements Client {
     const pending = this.pendingElicitation.value;
     if (pending && pending.elicitationId === params.elicitationId) {
       this.resolveElicitation('accept');
+    }
+  }
+
+  /**
+   * Handle the ACP `terminal/*` RPCs by delegating to the Tauri backend
+   * (desktop only; the caller has already checked `terminalAvailable`). The
+   * agent uses these to run commands on the user's machine and read output.
+   */
+  private async handleTerminal(method: string, params: unknown): Promise<unknown> {
+    switch (method) {
+      case 'terminal/create': {
+        const p = params as CreateTerminalRequest;
+        const terminalId = await terminalCreate({
+          command: p.command,
+          args: p.args ?? [],
+          env: (p.env ?? []).map((e) => ({ name: e.name, value: e.value })),
+          cwd: p.cwd ?? null,
+          outputByteLimit: (p as { outputByteLimit?: number | null }).outputByteLimit ?? null,
+        });
+        return { terminalId } as CreateTerminalResponse;
+      }
+      case 'terminal/output': {
+        const p = params as TerminalOutputRequest;
+        const res = await terminalOutput(p.terminalId);
+        return {
+          output: res.output,
+          truncated: res.truncated,
+          exitStatus: res.exitStatus ?? undefined,
+        } as TerminalOutputResponse;
+      }
+      case 'terminal/wait_for_exit': {
+        const p = params as WaitForTerminalExitRequest;
+        const status = await terminalWaitForExit(p.terminalId);
+        return {
+          exitCode: status.exitCode ?? undefined,
+          signal: status.signal ?? undefined,
+        } as WaitForTerminalExitResponse;
+      }
+      case 'terminal/kill': {
+        const p = params as KillTerminalRequest;
+        await terminalKill(p.terminalId);
+        return {} as KillTerminalResponse;
+      }
+      case 'terminal/release': {
+        const p = params as ReleaseTerminalRequest;
+        await terminalRelease(p.terminalId);
+        return {} as ReleaseTerminalResponse;
+      }
+      default:
+        throw new Error(`Unhandled terminal method: ${method}`);
     }
   }
 

--- a/src/lib/host/index.ts
+++ b/src/lib/host/index.ts
@@ -287,6 +287,24 @@ export async function getAppVersion(): Promise<string> {
   return v ?? FALLBACK_VERSION;
 }
 
+/**
+ * Open a URL in the user's default external browser.
+ *
+ * In a Tauri webview `window.open()` / `<a target="_blank">` do NOT reach the
+ * system browser (they no-op or try to navigate the webview), so we go through
+ * the opener plugin. On the plain web build we fall back to `window.open`,
+ * which runs synchronously here to stay inside the click's user-gesture and
+ * avoid popup blocking.
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isTauriHost()) {
+    const { openUrl } = await import('@tauri-apps/plugin-opener');
+    await openUrl(url);
+    return;
+  }
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
 /** True when the host can present a native folder picker. */
 export function canPickFolder(): boolean {
   return isDesktop();

--- a/src/lib/host/index.ts
+++ b/src/lib/host/index.ts
@@ -344,6 +344,70 @@ export async function writeTextFile(path: string, content: string): Promise<void
 }
 
 // ---------------------------------------------------------------------------
+// Terminal RPCs (Tauri desktop only). Back the ACP `terminal/*` capability by
+// spawning/managing processes in the Rust backend.
+// ---------------------------------------------------------------------------
+
+export interface TerminalExitStatus {
+  exitCode?: number | null;
+  signal?: string | null;
+}
+
+export interface TerminalOutputResult {
+  output: string;
+  truncated: boolean;
+  exitStatus?: TerminalExitStatus | null;
+}
+
+export interface CreateTerminalOptions {
+  command: string;
+  args?: string[];
+  env?: { name: string; value: string }[];
+  cwd?: string | null;
+  outputByteLimit?: number | null;
+}
+
+function throwNoTerminal(): never {
+  throw new Error('terminal is not supported on this platform');
+}
+
+export async function terminalCreate(opts: CreateTerminalOptions): Promise<string> {
+  if (!isTauriHost()) throwNoTerminal();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<string>('terminal_create', {
+    command: opts.command,
+    args: opts.args ?? [],
+    env: opts.env ?? [],
+    cwd: opts.cwd ?? null,
+    outputByteLimit: opts.outputByteLimit ?? null,
+  });
+}
+
+export async function terminalOutput(terminalId: string): Promise<TerminalOutputResult> {
+  if (!isTauriHost()) throwNoTerminal();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<TerminalOutputResult>('terminal_output', { terminalId });
+}
+
+export async function terminalWaitForExit(terminalId: string): Promise<TerminalExitStatus> {
+  if (!isTauriHost()) throwNoTerminal();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<TerminalExitStatus>('terminal_wait_for_exit', { terminalId });
+}
+
+export async function terminalKill(terminalId: string): Promise<void> {
+  if (!isTauriHost()) throwNoTerminal();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<void>('terminal_kill', { terminalId });
+}
+
+export async function terminalRelease(terminalId: string): Promise<void> {
+  if (!isTauriHost()) throwNoTerminal();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<void>('terminal_release', { terminalId });
+}
+
+// ---------------------------------------------------------------------------
 // Re-exports
 // ---------------------------------------------------------------------------
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,6 +108,19 @@ export interface PermissionOption {
   optionId: string;
 }
 
+// Elicitation (URL mode) — a server→client request asking the user to visit
+// an authorization URL (e.g. a 3LO tool grant on a GlobAI agent) so a tool
+// can proceed. Mirrors the SDK's URL-mode `CreateElicitationRequest`, reduced
+// to what the dialog needs.
+export interface ElicitationRequest {
+  elicitationId: string;
+  message: string;
+  url: string;
+}
+
+/** User's response to a URL-mode elicitation. */
+export type ElicitationAction = 'accept' | 'decline' | 'cancel';
+
 // Session Modes
 export interface SessionMode {
   id: string;

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -10,7 +10,7 @@ import { AcpClientBridge, createAcpClient } from '../lib/acp-bridge';
 import { onAgentStderr, spawnAgent, killAgent } from '../lib/host';
 import { isDesktop } from '../lib/platform';
 import { useConfigStore } from './config';
-import type { SessionNotification, AuthMethod } from '@agentclientprotocol/sdk';
+import type { SessionNotification, AuthMethod, SessionConfigOption, LoadSessionResponse } from '@agentclientprotocol/sdk';
 
 const STORE_PATH = 'sessions.json';
 const PROTOCOL_VERSION = 1;
@@ -34,6 +34,82 @@ function detectPhase(line: string): string | null {
     return 'starting';
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Session config options (SDK 1.3.0) — model picker plumbing.
+//
+// SDK 1.3.0 dropped `NewSessionResponse.models` in favour of a generic
+// `configOptions` list. The model selector is the `select` option the agent
+// tags with `category: "model"`. These helpers extract it into the shape the
+// existing ModelPicker already understands. All parsing is defensive: any
+// unexpected shape yields `null`, which simply hides the picker.
+// ---------------------------------------------------------------------------
+
+interface ModelConfig {
+  /** The config option's id, sent back as `configId` on set_config_option. */
+  configId: string;
+  models: ModelInfo[];
+  currentModelId: string;
+}
+
+/** True for a string that names the model selector but not model *params*. */
+function namesModel(s: unknown): boolean {
+  return typeof s === 'string' && /model/i.test(s) && !/model[_-]?config/i.test(s);
+}
+
+/** Flatten a select option's values, tolerating both flat and grouped forms. */
+function flattenSelectOptions(options: unknown): ModelInfo[] {
+  if (!Array.isArray(options)) return [];
+  const out: ModelInfo[] = [];
+  for (const opt of options) {
+    if (!opt || typeof opt !== 'object') continue;
+    const o = opt as Record<string, unknown>;
+    if (Array.isArray(o.options)) {
+      // Grouped: recurse into the group's options.
+      out.push(...flattenSelectOptions(o.options));
+    } else if (typeof o.value === 'string') {
+      out.push({
+        modelId: o.value,
+        name: typeof o.name === 'string' ? o.name : o.value,
+        description: typeof o.description === 'string' ? o.description : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the model selector among the session's config options and map it to the
+ * ModelPicker's shape. Prefers `category: "model"`; falls back to a select
+ * whose category/id/name names "model" (excluding "model_config").
+ */
+function parseModelConfig(configOptions: SessionConfigOption[] | null | undefined): ModelConfig | null {
+  if (!Array.isArray(configOptions)) return null;
+  const selects = configOptions.filter(
+    (o): o is SessionConfigOption & { type: 'select' } =>
+      !!o && typeof o === 'object' && (o as { type?: unknown }).type === 'select'
+  );
+  const modelOpt =
+    selects.find((o) => (o as { category?: unknown }).category === 'model') ??
+    selects.find((o) => {
+      const c = o as { category?: unknown; id?: unknown; name?: unknown };
+      return namesModel(c.category) || namesModel(c.id) || namesModel(c.name);
+    });
+  if (!modelOpt) return null;
+  const opt = modelOpt as unknown as {
+    id?: unknown;
+    currentValue?: unknown;
+    options?: unknown;
+  };
+  if (typeof opt.id !== 'string') return null;
+  const models = flattenSelectOptions(opt.options);
+  if (models.length === 0) return null;
+  return {
+    configId: opt.id,
+    models,
+    currentModelId: typeof opt.currentValue === 'string' ? opt.currentValue : '',
+  };
 }
 
 export const useSessionStore = defineStore('session', () => {
@@ -84,6 +160,24 @@ export const useSessionStore = defineStore('session', () => {
   // Current ACP client
   let acpClient: AcpClientBridge | null = null;
   let store: KVStore | null = null;
+  // Config option id of the model selector (SDK 1.3.0), needed to change it.
+  let modelConfigId: string | null = null;
+
+  // Populate the model picker from a session's config options (create/resume
+  // responses and `config_option_update` notifications). Clears when there's
+  // no recognisable model selector.
+  function applyConfigOptions(configOptions: SessionConfigOption[] | null | undefined): void {
+    const modelConfig = parseModelConfig(configOptions);
+    if (modelConfig) {
+      modelConfigId = modelConfig.configId;
+      availableModels.value = modelConfig.models;
+      currentModelId.value = modelConfig.currentModelId;
+    } else {
+      modelConfigId = null;
+      availableModels.value = [];
+      currentModelId.value = '';
+    }
+  }
 
   // Computed
   const hasActiveSession = computed(() => currentSession.value !== null);
@@ -239,6 +333,14 @@ export const useSessionStore = defineStore('session', () => {
         // Agent changed the mode
         if ('modeId' in update && update.modeId) {
           currentModeId.value = update.modeId as string;
+        }
+        break;
+
+      case 'config_option_update':
+        // SDK 1.3.0: the agent pushed the full set of config options (e.g. the
+        // model changed). Re-derive the model picker from it.
+        if ('configOptions' in update) {
+          applyConfigOptions((update as { configOptions?: SessionConfigOption[] }).configOptions);
         }
         break;
 
@@ -532,12 +634,8 @@ export const useSessionStore = defineStore('session', () => {
         currentModeId.value = '';
       }
 
-      // Session models: SDK 1.3.0 dropped the dedicated `models` field on
-      // NewSessionResponse in favour of the generic `configOptions` (session
-      // config options). The model picker is disabled until it's migrated to
-      // that API; see follow-up. Clearing keeps the picker hidden.
-      availableModels.value = [];
-      currentModelId.value = '';
+      // Model picker (SDK 1.3.0): derived from the session's config options.
+      applyConfigOptions(sessionResponse.configOptions);
 
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
@@ -656,8 +754,9 @@ export const useSessionStore = defineStore('session', () => {
       toolCalls.value.clear();
 
       // Try to load existing session - may fail with auth_required
+      let loadResponse: LoadSessionResponse | undefined;
       try {
-        await acpClient.loadSession({
+        loadResponse = await acpClient.loadSession({
           sessionId: savedSession.sessionId,
           cwd: savedSession.cwd,
           mcpServers: [],
@@ -686,7 +785,7 @@ export const useSessionStore = defineStore('session', () => {
           console.log('Authentication successful:', authResponse);
 
           // Retry loading session after auth
-          await acpClient.loadSession({
+          loadResponse = await acpClient.loadSession({
             sessionId: savedSession.sessionId,
             cwd: savedSession.cwd,
             mcpServers: [],
@@ -695,6 +794,11 @@ export const useSessionStore = defineStore('session', () => {
           throw sessionError;
         }
       }
+
+      // Model picker (SDK 1.3.0): populate from the resumed session's config
+      // options if the agent returned them. Live changes still arrive via
+      // config_option_update notifications during replay.
+      applyConfigOptions(loadResponse?.configOptions);
 
       currentSession.value = savedSession;
       isConnected.value = true;
@@ -861,6 +965,7 @@ export const useSessionStore = defineStore('session', () => {
     availableCommands.value = [];
     availableModels.value = [];
     currentModelId.value = '';
+    modelConfigId = null;
   }
 
   // Delete saved session
@@ -889,13 +994,19 @@ export const useSessionStore = defineStore('session', () => {
     if (!acpClient || !currentSession.value) {
       throw new Error('No active session');
     }
-    
-    await acpClient.unstable_setSessionModel({
+    if (!modelConfigId) {
+      throw new Error('No model config option available for this session');
+    }
+
+    // SDK 1.3.0: the model is a session config option, changed via
+    // session/set_config_option (configId = the model option's id).
+    await acpClient.unstable_setSessionConfigOption({
       sessionId: currentSession.value.sessionId,
-      modelId,
+      configId: modelConfigId,
+      value: modelId,
     });
-    
-    // Optimistically update the current model
+
+    // Optimistically update; a config_option_update may confirm/override.
     currentModelId.value = modelId;
   }
 

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -528,6 +528,10 @@ export const useSessionStore = defineStore('session', () => {
           elicitation: {
             url: {},
           },
+          // Terminal execution requires a local subprocess, so only desktop
+          // advertises it. Enables agents to run commands (ls, grep, git, …)
+          // and manipulate files beyond fs read/write.
+          terminal: canAccessFs,
         },
         clientInfo: {
           name: 'acp-ui',
@@ -738,6 +742,10 @@ export const useSessionStore = defineStore('session', () => {
           elicitation: {
             url: {},
           },
+          // Terminal execution requires a local subprocess, so only desktop
+          // advertises it. Enables agents to run commands (ls, grep, git, …)
+          // and manipulate files beyond fs read/write.
+          terminal: canAccessFs,
         },
         clientInfo: {
           name: 'acp-ui',

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -4,7 +4,7 @@ import { ref, computed, watch } from 'vue';
 import { loadKvStore, type KVStore } from '../lib/host/storage';
 import { getAppVersion } from '../lib/host';
 import { trackEvent, trackError } from '../lib/telemetry';
-import type { SavedSession, ChatMessage, ToolCallInfo, PermissionRequest, SessionMode, SlashCommand, ModelInfo, AgentConfig } from '../lib/types';
+import type { SavedSession, ChatMessage, ToolCallInfo, PermissionRequest, SessionMode, SlashCommand, ModelInfo, AgentConfig, ElicitationRequest, ElicitationAction } from '../lib/types';
 import { getTransportKind } from '../lib/types';
 import { AcpClientBridge, createAcpClient } from '../lib/acp-bridge';
 import { onAgentStderr, spawnAgent, killAgent } from '../lib/host';
@@ -52,6 +52,8 @@ export const useSessionStore = defineStore('session', () => {
   const isReconnecting = ref(false);
   const error = ref<string | null>(null);
   const pendingPermission = ref<PermissionRequest | null>(null);
+  // URL-mode elicitation currently awaiting the user (or auto-completion).
+  const pendingElicitation = ref<ElicitationRequest | null>(null);
   
   // Authentication state
   const pendingAuthMethods = ref<AuthMethod[]>([]);
@@ -127,6 +129,7 @@ export const useSessionStore = defineStore('session', () => {
     isConnected.value = false;
     isLoading.value = false;
     pendingPermission.value = null;
+    pendingElicitation.value = null;
     error.value = `Connection lost: ${reason ?? 'transport closed'}`;
   }
 
@@ -388,6 +391,16 @@ export const useSessionStore = defineStore('session', () => {
         { immediate: true }
       );
 
+      // Sync bridge's pendingElicitation to the store so the UI can show the
+      // URL-mode authorization dialog.
+      watch(
+        () => acpClient?.pendingElicitation.value,
+        (newValue) => {
+          pendingElicitation.value = newValue ?? null;
+        },
+        { immediate: true }
+      );
+
       if (connectionAborted) {
         await acpClient.disconnect();
         throw new Error('Connection cancelled');
@@ -406,6 +419,12 @@ export const useSessionStore = defineStore('session', () => {
           fs: {
             readTextFile: canAccessFs,
             writeTextFile: canAccessFs,
+          },
+          // Advertise URL-mode elicitation so agents (e.g. GlobAI) can drive
+          // tool authorization (3LO) via elicitation/create instead of getting
+          // a METHOD_NOT_FOUND. `unstable_` in the SDK; wire field is `url`.
+          elicitation: {
+            url: {},
           },
         },
         clientInfo: {
@@ -513,18 +532,12 @@ export const useSessionStore = defineStore('session', () => {
         currentModeId.value = '';
       }
 
-      // Set up session models if available
-      if (sessionResponse.models) {
-        availableModels.value = (sessionResponse.models.availableModels || []).map(m => ({
-          modelId: m.modelId,
-          name: m.name,
-          description: m.description ?? undefined,
-        }));
-        currentModelId.value = sessionResponse.models.currentModelId || '';
-      } else {
-        availableModels.value = [];
-        currentModelId.value = '';
-      }
+      // Session models: SDK 1.3.0 dropped the dedicated `models` field on
+      // NewSessionResponse in favour of the generic `configOptions` (session
+      // config options). The model picker is disabled until it's migrated to
+      // that API; see follow-up. Clearing keeps the picker hidden.
+      availableModels.value = [];
+      currentModelId.value = '';
 
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
@@ -599,6 +612,16 @@ export const useSessionStore = defineStore('session', () => {
         { immediate: true }
       );
 
+      // Sync bridge's pendingElicitation to the store so the UI can show the
+      // URL-mode authorization dialog.
+      watch(
+        () => acpClient?.pendingElicitation.value,
+        (newValue) => {
+          pendingElicitation.value = newValue ?? null;
+        },
+        { immediate: true }
+      );
+
       // Only Tauri desktop has real filesystem access; mobile and web
       // cannot fulfil readTextFile / writeTextFile RPCs.
       const canAccessFs = isDesktop();
@@ -610,6 +633,12 @@ export const useSessionStore = defineStore('session', () => {
           fs: {
             readTextFile: canAccessFs,
             writeTextFile: canAccessFs,
+          },
+          // Advertise URL-mode elicitation so agents (e.g. GlobAI) can drive
+          // tool authorization (3LO) via elicitation/create instead of getting
+          // a METHOD_NOT_FOUND. `unstable_` in the SDK; wire field is `url`.
+          elicitation: {
+            url: {},
           },
         },
         clientInfo: {
@@ -794,6 +823,15 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
+  // Answer a URL-mode elicitation (accept / decline / cancel). The bridge
+  // clears its own pending ref; the watch propagates that to the store.
+  function resolveElicitation(action: ElicitationAction): void {
+    if (acpClient) {
+      acpClient.resolveElicitation(action);
+    }
+    pendingElicitation.value = null;
+  }
+
   // Disconnect current session
   async function disconnect(): Promise<void> {
     const agentName = currentSession.value?.agentName || 'unknown';
@@ -816,6 +854,8 @@ export const useSessionStore = defineStore('session', () => {
     isConnected.value = false;
     messages.value = [];
     toolCalls.value.clear();
+    pendingPermission.value = null;
+    pendingElicitation.value = null;
     availableModes.value = [];
     currentModeId.value = '';
     availableCommands.value = [];
@@ -927,6 +967,7 @@ export const useSessionStore = defineStore('session', () => {
     isReconnecting,
     error,
     pendingPermission,
+    pendingElicitation,
     pendingAuthMethods,
     pendingAuthAgentName,
     availableModes,
@@ -953,6 +994,7 @@ export const useSessionStore = defineStore('session', () => {
     cancelConnection,
     resolvePermission,
     cancelPermission,
+    resolveElicitation,
     selectAuthMethod,
     cancelAuthSelection,
     disconnect,


### PR DESCRIPTION
## Summary

Implements the ACP **terminal** capability on the client so agents can run commands on the user's machine and read their output — enabling full local file manipulation (`ls`, `grep`, `rm`, `sed`, `git`, …) beyond `fs/read_text_file` + `fs/write_text_file`.

> **Stacked on #20** (SDK 1.3.0 + elicitation). This PR's diff includes #20's commits until that merges; the terminal-specific change is the single commit **`feat(terminal): implement ACP terminal capability (desktop)`** — review that one.

## Changes (terminal commit)

- **Rust `TerminalManager`** (`src-tauri/src/terminal.rs`): spawns through the user's login shell (PATH parity with `agent.rs`), combines stdout+stderr into one buffer with **byte-limit truncation at a UTF-8 boundary**, tracks exit code/signal, and exposes create / output / wait_for_exit / kill / release. Desktop-only; mobile builds stub-error.
- **Tauri commands** wired in `lib.rs`; **host wrappers** in `src/lib/host/index.ts`; **bridge handlers** for the five `terminal/*` RPCs (respond `-32601` off desktop).
- **Advertise** `clientCapabilities.terminal = true` on desktop.

## Contract

`terminal/create` `{ command, args?, env?, cwd?, outputByteLimit? }` → `{ terminalId }`; `terminal/output` → `{ output, truncated, exitStatus? }`; `terminal/wait_for_exit` → `{ exitCode?, signal? }`; `terminal/kill`, `terminal/release` → `{}`.

## Security

This grants the connected agent **arbitrary command execution** on the user's machine. It is gated to the desktop build and to clients advertising the capability. A user-facing opt-in (Settings toggle / per-command confirmation) is a reasonable follow-up.

## Testing

- `npx vue-tsc --noEmit` passes; the Rust backend compiles under `tauri dev`.
- End-to-end execution against a live agent that drives `terminal/*` is pending.
